### PR TITLE
Background section added - Contributors section continued

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 # phis2-docs-community
-Users documentation of PHIS2
 
 ## Overview
+This repository contains PHIS2 users documentation.
 
-PHIS stands for Phenotyping Hybrid Information System.
+## Background
+PHIS (Phenotyping Hybrid Information System) is developped for high-throughput plant phenotyping in close interaction to plant phenotyping communities.
+PHIS is part of SILEX collaborative meta-project developped at MISTEA joint research unit (INRA - SupAgro).
+More information on SILEX is availbale at [SILEX wiki](https://mulcyber.toulouse.inra.fr/plugins/mediawiki/wiki/silex/index.php/Accueil "SILEX wiki Main Page").
+PHIS2 refers to the PHIS version developped for field phenotyping.
 
-# Contributors
+## Contributors
+UMR MISTEA (INRA - SupAgro), Montpellier :
+- Anne Tireau
+- Morgane Vidal
+- Pierre-Etienne Alary
 
+Every PHIS2 user is welcomed to enrich this repository with its experience of the information system.


### PR DESCRIPTION
Background section added with SILEX wiki link
Contributors section continued with the main repository contributors name and the statement that users can contribute to the present documentation